### PR TITLE
fix: missing thumbnail in Amazon Link

### DIFF
--- a/src/summary/amazon/index.ts
+++ b/src/summary/amazon/index.ts
@@ -14,7 +14,7 @@ import getSensitive from "../general/sensitive";
 export default function amazon(url: URL, html: HTMLRewriter) {
   const card = getCard(url, html);
   const title = getTitle(url, html);
-  const image = getImage(url, html);
+  const thumbnail = getImage(url, html);
   const player = Promise.all([
     card,
     getPlayerUrlGeneral(url, html),
@@ -44,14 +44,14 @@ export default function amazon(url: URL, html: HTMLRewriter) {
 
   return Promise.all([
     title,
-    image,
+    thumbnail,
     player,
     description,
     siteName,
     favicon,
     sensitive,
   ]).then(
-    ([title, image, player, description, siteName, favicon, sensitive]) => {
+    ([title, thumbnail, player, description, siteName, favicon, sensitive]) => {
       if (title === null) {
         return null;
       }
@@ -60,7 +60,7 @@ export default function amazon(url: URL, html: HTMLRewriter) {
       }
       return {
         title,
-        image,
+        thumbnail,
         description: title === description ? null : description,
         player,
         allow: [],


### PR DESCRIPTION
## What

Amazonリンクにサムネイルが表示されるように修正しました。

![image](https://github.com/misskey-dev/summerflare/assets/44333881/f9a9d50d-f48a-43f1-adb0-f342ce8b669c)

## Why

Amazonリンクにサムネイルが表示されなかったため。

![image](https://github.com/misskey-dev/summerflare/assets/44333881/f270c85c-dcdf-4d72-b796-bf134689932c)